### PR TITLE
Parse metadata from CID

### DIFF
--- a/db/migrations/1679317828391-additionalFieldsForMetadata.js
+++ b/db/migrations/1679317828391-additionalFieldsForMetadata.js
@@ -1,0 +1,25 @@
+module.exports = class Data1679317828391 {
+  name = 'Data1679317828391'
+
+  async up(db) {
+    await db.query(`ALTER TABLE "battlepass" ADD "description" text`)
+    await db.query(`ALTER TABLE "battlepass" ADD "image" text`)
+    await db.query(`ALTER TABLE "nft_collection" ADD "name" text`)
+    await db.query(`ALTER TABLE "nft_collection" ADD "description" text`)
+    await db.query(`ALTER TABLE "nft_collection" ADD "image" text`)
+    await db.query(`ALTER TABLE "nft" ADD "name" text`)
+    await db.query(`ALTER TABLE "nft" ADD "description" text`)
+    await db.query(`ALTER TABLE "nft" ADD "image" text`)
+  }
+
+  async down(db) {
+    await db.query(`ALTER TABLE "battlepass" DROP COLUMN "description"`)
+    await db.query(`ALTER TABLE "battlepass" DROP COLUMN "image"`)
+    await db.query(`ALTER TABLE "nft_collection" DROP COLUMN "name"`)
+    await db.query(`ALTER TABLE "nft_collection" DROP COLUMN "description"`)
+    await db.query(`ALTER TABLE "nft_collection" DROP COLUMN "image"`)
+    await db.query(`ALTER TABLE "nft" DROP COLUMN "name"`)
+    await db.query(`ALTER TABLE "nft" DROP COLUMN "description"`)
+    await db.query(`ALTER TABLE "nft" DROP COLUMN "image"`)
+  }
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -206,6 +206,8 @@ type Battlepass @entity {
 
     # Metadata:
     cid: String!
+    description: String
+    image: String
 }
 
 type BattlepassNft @entity {
@@ -221,6 +223,11 @@ type Nft @entity {
     metadata: String
     metadataIsFrozen: Boolean
     collection: NftCollection!
+
+    # Metadata:
+    name: String
+    description: String
+    image: String
 }
 
 type NftCollection @entity {
@@ -229,4 +236,9 @@ type NftCollection @entity {
     metadata: String
     metadataIsFrozen: Boolean
     max: Int
+
+    # Metadata:
+    name: String
+    description: String
+    image: String
 }

--- a/src/common/ipfs/getters.ts
+++ b/src/common/ipfs/getters.ts
@@ -76,4 +76,4 @@ async function fetchProposalMetadata(cid: string, proposalId: string): Promise<P
     return await fetchMetadata(cid, proposalId, 'proposal', metadata);
 }
 
-export { fetchOrgMetadata, fetchCampaignMetadata, fetchProposalMetadata };
+export { fetchOrgMetadata, fetchCampaignMetadata, fetchProposalMetadata, fetchMetadata };

--- a/src/mappings/battlepass/events/battlepassUpdated.ts
+++ b/src/mappings/battlepass/events/battlepassUpdated.ts
@@ -3,6 +3,7 @@ import { Event } from '../../../types/generated/support'
 
 import { getBattlepassUpdatedData } from './getters'
 import { getBattlepass } from '../../../common/db/getters'
+import { fetchMetadata } from '../../../common/ipfs/getters'
 
 import { arrayToHexString } from '../../../common/tools'
 import { ObjectNotExistsWarn } from '../../../common/errors'
@@ -20,7 +21,15 @@ async function handleBattlepassUpdatedEvent(ctx: Context, block: Block, event: E
 
     if (battlepassName) battlepass.name = battlepassName.toString()
     if (price) battlepass.price = BigInt(price)
-    if (cid) battlepass.cid = cid.toString()
+    if (cid) {
+        battlepass.cid = cid.toString()
+
+        // Fetch metadata from ipfs
+        let metadata = await fetchMetadata(battlepass.cid, bpassId, 'battlepass', null)
+        battlepass.name = metadata?.name ?? battlepass.name
+        battlepass.description = metadata?.description ?? battlepass.description
+        battlepass.image = metadata?.image ?? battlepass.image
+    }
 
     await ctx.store.save(battlepass)
 }

--- a/src/mappings/control/events/orgCreated.ts
+++ b/src/mappings/control/events/orgCreated.ts
@@ -76,10 +76,7 @@ async function handleOrgCreatedEvent(ctx: Context, block: Block, event: Event, n
     org.url = metadata?.url ?? ''
     org.location = metadata?.location ?? ''
     org.tags = metadata?.tags ?? []
-
-    // TODO: pottential duplicates, there is no uniqueness check implemented
-    // TODO: if the "name" was updated on IPFS, we have no callback to update the slug
-    org.slug = slugify(org.name)
+    org.slug = slugify(org.name + '-' + org.id)
 
     await ctx.store.save(org)
 }

--- a/src/mappings/control/events/orgUpdated.ts
+++ b/src/mappings/control/events/orgUpdated.ts
@@ -5,8 +5,9 @@ import { getOrgUpdatedData } from './getters'
 import { getOrg } from '../../../common/db/getters'
 import { upsertIdentity } from '../../../common/db/identity'
 import { storage } from '../../../storage'
+import { fetchOrgMetadata } from '../../../common/ipfs/getters'
 
-import { addressCodec, arrayToHexString } from '../../../common/tools'
+import { addressCodec, arrayToHexString, slugify } from '../../../common/tools'
 import { ObjectNotExistsWarn, StorageNotExistsWarn } from '../../../common/errors'
 
 
@@ -51,6 +52,20 @@ async function handleOrgUpdatedEvent(ctx: Context, block: Block, event: Event, n
     }
     if (storageData.cid) {
         org.cid = storageData.cid.toString();
+
+        // Fetch metadata from ipfs
+        let metadata = await fetchOrgMetadata(org.cid, orgId)
+        org.name = metadata?.name ?? org.name
+        org.description = metadata?.description ?? org.description
+        org.website = metadata?.website ?? org.website
+        org.email = metadata?.email ?? org.email
+        org.repo = metadata?.repo ?? org.repo
+        org.logo = metadata?.logo ?? org.logo
+        org.header = metadata?.header ?? org.header
+        org.url = metadata?.url ?? org.url
+        org.location = metadata?.location ?? org.location
+        org.tags = metadata?.tags ?? org.tags
+        org.slug = slugify(org.name + '-' + org.id)
     }
 
     org.updatedAtBlock = block.header.height;

--- a/src/mappings/flow/events/campaignCreated.ts
+++ b/src/mappings/flow/events/campaignCreated.ts
@@ -64,7 +64,7 @@ async function handleCampaignCreatedEvent(ctx: Context, block: Block, event: Eve
 
     // Fetch metadata from ipfs
     let metadata = await fetchCampaignMetadata(campaign.cid, orgId);
-    campaign.name = metadata?.name ?? '';
+    campaign.name = metadata?.name ?? storageData.name.toString();
     campaign.email = metadata?.email ?? '';
     campaign.title = metadata?.title ?? '';
     campaign.description = metadata?.description ?? '';

--- a/src/mappings/signal/events/proposalCreated.ts
+++ b/src/mappings/signal/events/proposalCreated.ts
@@ -84,7 +84,7 @@ async function handleProposalCreatedEvent(ctx: Context, block: Block, event: Eve
 
     // Fetch metadata from ipfs
     let metadata = await fetchProposalMetadata(proposalData.cid.toString(), proposalId)
-    proposal.name = metadata?.name ?? ''
+    proposal.name = metadata?.name ?? proposalData.title.toString()
     proposal.description = metadata?.description ?? ''
     await ctx.store.save(proposal)
 }

--- a/src/mappings/uniques/events/collectionMetadataSet.ts
+++ b/src/mappings/uniques/events/collectionMetadataSet.ts
@@ -5,6 +5,7 @@ import { getCollectionMetadataSetData } from './getters'
 import { getNftCollection } from '../../../common/db/getters'
 
 import { ObjectNotExistsWarn } from '../../../common/errors'
+import { fetchMetadata } from '../../../common/ipfs/getters'
 
 
 async function handleCollectionMetadataSetEvent(ctx: Context, block: Block, event: Event, name: string) {
@@ -18,6 +19,12 @@ async function handleCollectionMetadataSetEvent(ctx: Context, block: Block, even
 
     collection.metadata = metadata.toString()
     collection.metadataIsFrozen = isFrozen
+
+    // Fetch metadata from ipfs
+    let meta = await fetchMetadata(collection.metadata, collectionId.toString(), 'collection', null)
+    collection.name = meta?.name ?? collection.name
+    collection.description = meta?.description ?? collection.description
+    collection.image = meta?.image ?? collection.image
 
     await ctx.store.save(collection)
 }

--- a/src/mappings/uniques/events/nftMetadataSet.ts
+++ b/src/mappings/uniques/events/nftMetadataSet.ts
@@ -5,6 +5,7 @@ import { getNftMetadataSetData } from './getters'
 import { getNft } from '../../../common/db/getters'
 
 import { ObjectNotExistsWarn } from '../../../common/errors'
+import { fetchMetadata } from '../../../common/ipfs/getters'
 
 
 async function handleNftMetadataSetEvent(ctx: Context, block: Block, event: Event, name: string) {
@@ -18,6 +19,12 @@ async function handleNftMetadataSetEvent(ctx: Context, block: Block, event: Even
 
     nft.metadata = metadata.toString()
     nft.metadataIsFrozen = isFrozen
+
+    // Fetch metadata from ipfs
+    let meta = await fetchMetadata(nft.metadata, nftId.toString(), 'nft', null)
+    nft.name = meta?.name ?? nft.name
+    nft.description = meta?.description ?? nft.description
+    nft.image = meta?.image ?? nft.image
 
     await ctx.store.save(nft)
 }

--- a/src/model/generated/battlepass.model.ts
+++ b/src/model/generated/battlepass.model.ts
@@ -46,4 +46,10 @@ export class Battlepass {
 
   @Column_("text", {nullable: false})
   cid!: string
+
+  @Column_("text", {nullable: true})
+  description!: string | undefined | null
+
+  @Column_("text", {nullable: true})
+  image!: string | undefined | null
 }

--- a/src/model/generated/nft.model.ts
+++ b/src/model/generated/nft.model.ts
@@ -24,4 +24,13 @@ export class Nft {
   @Index_()
   @ManyToOne_(() => NftCollection, {nullable: true})
   collection!: NftCollection
+
+  @Column_("text", {nullable: true})
+  name!: string | undefined | null
+
+  @Column_("text", {nullable: true})
+  description!: string | undefined | null
+
+  @Column_("text", {nullable: true})
+  image!: string | undefined | null
 }

--- a/src/model/generated/nftCollection.model.ts
+++ b/src/model/generated/nftCollection.model.ts
@@ -22,4 +22,13 @@ export class NftCollection {
 
   @Column_("int4", {nullable: true})
   max!: number | undefined | null
+
+  @Column_("text", {nullable: true})
+  name!: string | undefined | null
+
+  @Column_("text", {nullable: true})
+  description!: string | undefined | null
+
+  @Column_("text", {nullable: true})
+  image!: string | undefined | null
 }


### PR DESCRIPTION
+ `Battlepass`, `Nft` and `NftCollection` entities extended with additional meta fields and populated with data fetched from IPFS.
+ update Org meta fields when CID changed
+ add ID to Org's slug
+ fix: get Campaign and Proposal `name` from storage if CID not provided